### PR TITLE
Release/v1.3.1

### DIFF
--- a/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/.env
+++ b/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/.env
@@ -8,3 +8,6 @@ DEBUG=true
 APP_SECRET=base64encoded==value==
 
 MyConfig=MyConfigDotEnv
+
+ObjConfig__Prop1=Prop1DotEnv
+ObjConfig__Obj2__Prop2=Prop2DotEnv

--- a/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/Program.cs
+++ b/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/Program.cs
@@ -1,9 +1,10 @@
 using Microsoft.Extensions.Configuration;
+
 using Sagi.Sdk.DotEnv.Extensions;
 
 // Demonstração 1: AddDotEnv() sem argumentos — busca .env no diretório atual
 IConfiguration config1 = new ConfigurationBuilder()
-    .AddDotEnv()
+    .AddDotEnv(opt => opt.Directory = AppContext.BaseDirectory)
     .Build();
 
 Console.WriteLine("=== AddDotEnv() sem argumentos ===");
@@ -18,6 +19,7 @@ Console.WriteLine();
 IConfiguration config2 = new ConfigurationBuilder()
     .AddDotEnv(opt =>
     {
+        opt.Directory = AppContext.BaseDirectory;
         opt.FileName = ".env";
     })
     .Build();
@@ -32,10 +34,38 @@ Console.WriteLine();
 
 // Demonstração 3: Sobreescrevendo appsettings
 IConfiguration config3 = new ConfigurationBuilder()
+    .SetBasePath(AppContext.BaseDirectory)
     .AddJsonFile("appsettings.json")
-    .AddDotEnv()
+    .AddDotEnv(opt => opt.Directory = AppContext.BaseDirectory)
     .Build();
 
 Console.WriteLine("=== Overwriting AppSettings ===");
 Console.WriteLine($"MyConfig : {config3["MyConfig"]}");
 Console.WriteLine($"MyOtherConfig : {config3["MyOtherConfig"]}");
+
+Console.WriteLine();
+
+// Demonstração 4: Fazendo bind com Objeto complexo
+IConfiguration config4 = new ConfigurationBuilder()
+    .SetBasePath(AppContext.BaseDirectory)
+    .AddJsonFile("appsettings.json")
+    .AddDotEnv()
+    .Build();
+
+var obj = config4.GetSection("ObjConfig").Get<Obj1>();
+
+Console.WriteLine("=== Binding with Complex Objects ===");
+Console.WriteLine($"obj?.Prop1 : {obj?.Prop1}");
+Console.WriteLine($"obj?.Obj2.Prop2 : {obj?.Obj2.Prop2}");
+
+
+class Obj1
+{
+    public string Prop1 { get; set; } = "";
+    public Obj2 Obj2 { get; set; } = new();
+}
+
+class Obj2
+{
+    public string Prop2 { get; set; } = "";
+}

--- a/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/Sagi.Sdk.DotEnv.Sample.csproj
+++ b/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/Sagi.Sdk.DotEnv.Sample.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
   </ItemGroup>
 

--- a/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/appsettings.json
+++ b/Sagi.Sdk.DotEnv/samples/Sagi.Sdk.DotEnv.Sample/appsettings.json
@@ -1,4 +1,10 @@
 {
   "MyConfig": "MyConfigAppSettings",
-  "MyOtherConfig": "MyOtherConfigAppSettings"
+  "MyOtherConfig": "MyOtherConfigAppSettings",
+  "ObjConfig":{
+    "Prop1": "Prop1AppSettings",
+    "Obj2":{
+      "Prop2": "Prop2AppSettings"
+    }
+  }
 }

--- a/Sagi.Sdk.DotEnv/src/Sagi.Sdk.DotEnv/Provider/DotEnvProvider.cs
+++ b/Sagi.Sdk.DotEnv/src/Sagi.Sdk.DotEnv/Provider/DotEnvProvider.cs
@@ -22,7 +22,9 @@ public class DotEnvProvider : ConfigurationProvider
         IReadOnlyDictionary<string, string> entries = DotEnvParser.Parse(lines);
 
         Data = new Dictionary<string, string?>(
-            entries.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value),
+            entries.ToDictionary(
+                kvp => kvp.Key.Replace("__", ConfigurationPath.KeyDelimiter),
+                kvp => (string?)kvp.Value),
             StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/Sagi.Sdk.DotEnv/tests/Sagi.Sdk.DotEnv.Tests/Provider/DotEnvProviderTests.cs
+++ b/Sagi.Sdk.DotEnv/tests/Sagi.Sdk.DotEnv.Tests/Provider/DotEnvProviderTests.cs
@@ -62,4 +62,30 @@ public class DotEnvProviderTests : IDisposable
         Assert.Null(ex);
         Assert.False(provider.TryGet("ANY", out _));
     }
+
+    [Fact]
+    public void Load_HierarchicalKeys_ConvertsDoubleUnderscoreToColon()
+    {
+        string envFile = Path.Combine(_tempDir, ".env");
+        File.WriteAllLines(envFile, [
+            "Database__Host=localhost",
+            "Database__Port=5432",
+            "Database__Credentials__Username=admin",
+            "Database__Credentials__Password=secret"
+        ]);
+
+        DotEnvOptions options = new() { Directory = _tempDir, FileName = ".env" };
+        DotEnvProvider provider = new(options);
+
+        provider.Load();
+
+        Assert.True(provider.TryGet("Database:Host", out string? host));
+        Assert.Equal("localhost", host);
+        Assert.True(provider.TryGet("Database:Port", out string? port));
+        Assert.Equal("5432", port);
+        Assert.True(provider.TryGet("Database:Credentials:Username", out string? username));
+        Assert.Equal("admin", username);
+        Assert.True(provider.TryGet("Database:Credentials:Password", out string? password));
+        Assert.Equal("secret", password);
+    }
 }

--- a/Sagi.Sdk.MongoDb/src/Sagi.Sdk.MongoDb/Sagi.Sdk.MongoDb.csproj
+++ b/Sagi.Sdk.MongoDb/src/Sagi.Sdk.MongoDb/Sagi.Sdk.MongoDb.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.5" />    
     <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sagi.Sdk.MongoDb/tests/Sagi.Sdk.MongoDb.Tests/Sagi.Sdk.MongoDb.Tests.csproj
+++ b/Sagi.Sdk.MongoDb/tests/Sagi.Sdk.MongoDb.Tests/Sagi.Sdk.MongoDb.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## fix(mongo): atualiza Snappier para 1.3.1 corrigindo CVE-2026-44302
    
    Resolve vulnerabilidade de severidade High no pacote Snappier que permitia
    loop infinito não capturável ao descomprimir streams Snappy malformados.
    
    Mudanças:
    - Adiciona referência explícita ao Snappier 1.3.1 em Sagi.Sdk.MongoDb
    - Adiciona referência explícita ao Snappier 1.3.1 em Sagi.Sdk.MongoDb.Tests
    - Sobrescreve dependência transitiva vulnerável (1.0.0) do MongoDB.Driver
    
    A vulnerabilidade (GHSA-pggp-6c3x-2xmx) causava busy loop consumindo 100%
    de CPU quando SnappyStream processava dados maliciosos. Versão 1.3.1
    lançada em 28/04/2026 corrige o problema.
    
    Refs: https://github.com/advisories/GHSA-pggp-6c3x-2xmx

## feat(dotenv): adiciona suporte a binding com objetos complexos
    
    Implementa conversão automática de __ (double underscore) para : (colon)
    no DotEnvProvider, permitindo binding hierárquico com objetos complexos
    via IConfiguration.GetSection().Get<T>().
    
    Mudanças:
    - DotEnvProvider: converte __ para ConfigurationPath.KeyDelimiter ao carregar variáveis
    - Sample: adiciona demonstração 4 com binding de objeto complexo (Obj1 com Obj2 aninhado)
    - Sample: ajusta para usar AppContext.BaseDirectory em todas as demonstrações
    - Sample.csproj: adiciona Microsoft.Extensions.Configuration.Binder 10.0.7
    - appsettings.json: adiciona seção ObjConfig para teste de override
    - .env: adiciona ObjConfig__Prop1 e ObjConfig__Obj2__Prop2
    - DotEnvProviderTests: adiciona teste Load_HierarchicalKeys_ConvertsDoubleUnderscoreToColon
    
    Exemplo de uso:
    // .env
    ObjConfig__Prop1=Value1
    ObjConfig__Obj2__Prop2=Value2
    
    // C#
    var obj = config.GetSection("ObjConfig").Get<Obj1>();
    // obj.Prop1 = "Value1"
    // obj.Obj2.Prop2 = "Value2"
    
    Testes: 26/26 passando (novo teste incluído)